### PR TITLE
added retry callback

### DIFF
--- a/phery.js
+++ b/phery.js
@@ -600,6 +600,9 @@
 			'fail':function () {
 				return true;
 			},
+			'retry':function () {
+				return true;
+			},
 			'progress':function () {
 				return true;
 			},
@@ -1029,6 +1032,7 @@
 
 						if (this.try_count <= this.retry_limit) {
 							functions.trigger_phery_event(dispatch_event, 'before');
+							functions.trigger_phery_event(dispatch_event, 'retry', [xhr, this.try_count]);
 
 							this.dataType = 'text ' + type;
 


### PR DESCRIPTION
If an ajax request times out and retry is enabled the retry event fires returning the try_count.
Handy if you want to inform the end user what's going on.

P.S. I added the 'retry' trigger after the 'before' trigger in the _fail routine for a specific reason. 'before' shows the loading... dialogue, 'retry' modifies the dialogues text to retrying... (1), retrying... (2), retrying... (3) etc.
