### PR TITLE
PheryResponse call() this context

### DIFF
--- a/phery.js
+++ b/phery.js
@@ -1369,7 +1369,7 @@
 							tmp = functions.assign_object(window, argv[0], undefined, false);
 
 							if (tmp !== false && typeof tmp[0][tmp[1]] === 'function') {
-								tmp[0][tmp[1]].apply(null, argv[1] || []);
+								tmp[0][tmp[1]].apply(tmp[0], argv[1] || []);
 							} else {
 								throw 'no function "' + (tmp.join('.')) + '" found';
 							}


### PR DESCRIPTION
When using the PheryResponse object to call a javascript function nested in an object variable, the "this" context of the function is the "window" object.
If you rely on other methods/properties of this object they are not relatively accessible.
For example

php

```
PheryResponse::factory()->call(array('my_object','my_function'), $my_parameters)
```

javascript

```
var my_object = {
    my_property: 'hello world',
    my_function: function(){
        console.log('this=', this);
        console.log('my_property=', this.my_property);
    }
}
```

When you run this you get this=window and my_property=undefined

Now the small edit i've made makes it work as you would hope i.e. this=my_object
As i'm not 100 percent with the code base i may well have broken something else... I think only Paulo can determine that.
cheers
mh
