### PR TITLE
feature: initial support for PHPStan and resolve some PHP 8.2 depreca…

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,10 @@
         }
     ],
     "require": {
-        "php": ">=5.3.3"
+        "php": ">=8.0"
+    },
+    "require-dev": {
+        "phpstan/phpstan": "^1.10"
     },
     "autoload": {
         "psr-4": {

--- a/src/Phery/Phery.php
+++ b/src/Phery/Phery.php
@@ -1302,10 +1302,8 @@ class Phery implements ArrayAccess
      * OffsetExists
      *
      * @param mixed $offset
-     *
-     * @return bool
      */
-    public function offsetExists($offset)
+    public function offsetExists($offset) : bool
     {
         return isset($this->data[$offset]);
     }
@@ -1315,7 +1313,7 @@ class Phery implements ArrayAccess
      *
      * @param mixed $offset
      */
-    public function offsetUnset($offset)
+    public function offsetUnset($offset) : void
     {
         if (isset($this->data[$offset])) {
             unset($this->data[$offset]);
@@ -1326,10 +1324,8 @@ class Phery implements ArrayAccess
      * OffsetGet
      *
      * @param mixed $offset
-     *
-     * @return mixed|null
      */
-    public function offsetGet($offset)
+    public function offsetGet($offset) : mixed
     {
         if (isset($this->data[$offset])) {
             return $this->data[$offset];
@@ -1344,7 +1340,7 @@ class Phery implements ArrayAccess
      * @param mixed $offset
      * @param mixed $value
      */
-    public function offsetSet($offset, $value)
+    public function offsetSet($offset, $value) : void
     {
         $this->data[$offset] = $value;
     }

--- a/src/Phery/PheryResponse.php
+++ b/src/Phery/PheryResponse.php
@@ -568,10 +568,8 @@ class PheryResponse extends ArrayObject
      * Will check for globals and local values
      *
      * @param string|int $index
-     *
-     * @return mixed
      */
-    public function offsetExists($index)
+    public function offsetExists($index) : bool
     {
         if (isset(self::$global[$index])) {
             return true;
@@ -585,10 +583,8 @@ class PheryResponse extends ArrayObject
      *
      * @param string|int|null $index
      * @param mixed $newval
-     *
-     * @return void
      */
-    public function offsetSet($index, $newval)
+    public function offsetSet($index, $newval) : void
     {
         if ($index === null) {
             $this[] = $newval;
@@ -601,10 +597,8 @@ class PheryResponse extends ArrayObject
      * Return null if no value
      *
      * @param mixed $index
-     *
-     * @return mixed|null
      */
-    public function offsetGet($index)
+    public function offsetGet($index) : mixed
     {
         if (parent::offsetExists($index)) {
             return parent::offsetGet($index);
@@ -1339,6 +1333,7 @@ class PheryResponse extends ArrayObject
      *
      * @return PheryResponse
      */
+    #[\ReturnTypeWillChange]
     public function append($content, $selector = null)
     {
         if (is_array($content)) {


### PR DESCRIPTION
When running 

```bash
vendor/bin/phpstan analyse src
```

One error remains:

```
  Line   Phery/Phery.php                                                      
 ------ --------------------------------------------------------------------- 
  627    Function get_magic_quotes_gpc not found.                             
         💡 Learn more at https://phpstan.org/user-guide/discovering-symbols  
```

That issue is resolved by https://github.com/pheryjs/phery/pull/60

Can you also merge the `3.0.0-alpha1` (which has most changes) into master?